### PR TITLE
fix: revision_url misspelling. Shorten notification rule name to fit 64 char character limit

### DIFF
--- a/cloudfomation.yaml
+++ b/cloudfomation.yaml
@@ -133,7 +133,7 @@ Resources:
   PipelineNotificationRule:
     Type: 'AWS::CodeStarNotifications::NotificationRule'
     Properties:
-      Name: !Sub 'Notification for ${PipelineName} ${AWS::StackName}'
+      Name: !Sub 'Notification for ${PipelineName}'
       DetailType: FULL
       Resource: !Sub 'arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${PipelineName}'
       EventTypeIds:
@@ -209,7 +209,7 @@ Resources:
             if "FullRepositoryId=" in revision_url:
               repo_id = revision_url.split("FullRepositoryId=")[1].split("&")[0]
             else: #gitbub v1 integration
-              repo_id = revision_url.split("/")[3] + "/" + revisionUrl.split("/")[4]
+              repo_id = revision_url.split("/")[3] + "/" + revision_url.split("/")[4]
 
 
             if integration_type == "Bitbucket":


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Fix `revision_url` misspelling. Without this fix the lambda function will not run to completion
*  Shorten notification rule name to fit 64 char character limit. Without this fix spinning up a CFN stack might cause the notification rule name to pass the 64 char limit, and the stack will not successfuly spin up. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
